### PR TITLE
finetune_language_layers issue fix

### DIFF
--- a/vlmgrpo/trainer.py
+++ b/vlmgrpo/trainer.py
@@ -29,7 +29,7 @@ from .patches import patch_requires_grad_post_hook
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from contextlib import nullcontext
 from transformers import GenerationConfig
-from types import  Optional
+
 import contextlib
 
 def compute_loss_context_manager(self):
@@ -38,7 +38,7 @@ def compute_loss_context_manager(self):
     """
     return self.autocast_smart_context_manager()
 
-def autocast_smart_context_manager(self, cache_enabled: Optional[bool] = True):
+def autocast_smart_context_manager(self, cache_enabled: bool = True):
     """
     A helper wrapper that creates an appropriate context manager for `autocast` while feeding it the desired
     arguments, depending on the situation.

--- a/vlmgrpo/trainer.py
+++ b/vlmgrpo/trainer.py
@@ -486,11 +486,9 @@ class VLMGRPOTrainer(GRPOTrainer):
 
         del inputs
         torch._functorch.config.donated_buffer = False 
-        loss = self.accelerator.backward(loss,retain_graph = True) # dummy implementation , need to add scale_wrt_gas attr for deepspeed
+        self.accelerator.backward(loss,retain_graph = True) # dummy implementation , need to add scale_wrt_gas attr for deepspeed
 
         grad_params = [p for p in model.parameters() if p.grad is not None]
-        
-        print(loss.grad_fn)
         
         total_norm = 0
         for p in grad_params:

--- a/vlmgrpo/trainer.py
+++ b/vlmgrpo/trainer.py
@@ -455,6 +455,7 @@ class VLMGRPOTrainer(GRPOTrainer):
 
         grad_params = [p for p in model.parameters() if p.grad is not None]
         
+        print(loss.grad_fn)
         
         total_norm = 0
         for p in grad_params:

--- a/vlmgrpo/trainer.py
+++ b/vlmgrpo/trainer.py
@@ -486,8 +486,7 @@ class VLMGRPOTrainer(GRPOTrainer):
 
         del inputs
         torch._functorch.config.donated_buffer = False 
-        accelerator = Trainer.accelerator
-        loss = accelerator.backward(loss,retain_graph = True) # dummy implementation , need to add scale_wrt_gas attr for deepspeed
+        loss = self.accelerator.backward(loss,retain_graph = True) # dummy implementation , need to add scale_wrt_gas attr for deepspeed
 
         grad_params = [p for p in model.parameters() if p.grad is not None]
         

--- a/vlmgrpo/trainer.py
+++ b/vlmgrpo/trainer.py
@@ -452,7 +452,10 @@ class VLMGRPOTrainer(GRPOTrainer):
         return loss
 
     def training_step(self, model, inputs, num_items_in_batch=None) -> torch.Tensor:
-        loss=super().training_step(model,inputs,num_items_in_batch)
+        # temporary patch for vision layer training
+        torch._functorch.config.donated_buffer = False 
+        accelerator = Trainer.accelerator
+        loss = accelerator.backward(loss,retain_graph = True) # dummy implementation , need to add scale_wrt_gas attr for deepspeed
 
         grad_params = [p for p in model.parameters() if p.grad is not None]
         

--- a/vlmgrpo/trainer.py
+++ b/vlmgrpo/trainer.py
@@ -195,6 +195,7 @@ class VLMGRPOTrainer(GRPOTrainer):
         prompt_inputs = Trainer._prepare_inputs(self, prompt_inputs)
         prompt_ids, prompt_mask = prompt_inputs["input_ids"], prompt_inputs["attention_mask"]
         pixel_values, image_grid_thw = prompt_inputs["pixel_values"], prompt_inputs["image_grid_thw"]
+        pixel_values.requires_grad = True
         is_eos_prompt = prompt_ids == self.processing_class.eos_token_id
         
         if self.max_prompt_length is not None:
@@ -381,19 +382,6 @@ class VLMGRPOTrainer(GRPOTrainer):
                       image_grid_thw=image_grid_thw, logits_to_keep=logits_to_keep + 1).logits
         logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
 
-        logits_without_vision = model(
-            input_ids=input_ids, attention_mask=attention_mask,
-            logits_to_keep=logits_to_keep + 1
-        ).logits
-
-        logits_with_vision = model(
-            input_ids=input_ids, attention_mask=attention_mask,
-            pixel_values=pixel_values, image_grid_thw=image_grid_thw,
-            logits_to_keep=logits_to_keep + 1
-        ).logits
-
-        diff = (logits_with_vision - logits_without_vision).abs().mean()
-        print(f"[DEBUG] Diff between with/without vision: {diff.item()}")
         input_ids = input_ids[:, -logits_to_keep:]
         # For transformers<=4.48, logits_to_keep argument isn't supported, so here we drop logits ourselves.
         # See https://github.com/huggingface/trl/issues/2770

--- a/vlmgrpo/trainer.py
+++ b/vlmgrpo/trainer.py
@@ -217,7 +217,7 @@ class VLMGRPOTrainer(GRPOTrainer):
         prompt_inputs = Trainer._prepare_inputs(self, prompt_inputs)
         prompt_ids, prompt_mask = prompt_inputs["input_ids"], prompt_inputs["attention_mask"]
         pixel_values, image_grid_thw = prompt_inputs["pixel_values"], prompt_inputs["image_grid_thw"]
-        pixel_values.requires_grad = True
+        pixel_values.requires_grad = True #this should be hooked instead, it's temporary 
         is_eos_prompt = prompt_ids == self.processing_class.eos_token_id
         
         if self.max_prompt_length is not None:


### PR DESCRIPTION
pre_hook from Unsloth was assuming that the model was an llm so it requires grad only for the text input, not vision input. 
Resulting in no backprop in the vision layers thus grad = 0 if you set finetune_language_layers = False.

Adresses [Issues #14](https://github.com/GAD-cell/vlm-grpo/issues/14).

Temporary fix : 
requires_grad = True for vision inputs during generate_and_score_completions execution (should be moved in  pre_hook method)
training_step modified to allow multiple backward pass (one for language layers, and one for vision layers) -> retain_graph = True and disabled donated_buffer.
